### PR TITLE
Delete _default_ ssl VirtualHost

### DIFF
--- a/4.2.1/docker-entrypoint.sh
+++ b/4.2.1/docker-entrypoint.sh
@@ -74,6 +74,7 @@ _vhost_conf () {
 }
 
 echo "IncludeOptional /etc/httpd/davrods_conf.d/*.conf" >> /etc/httpd/conf/httpd.conf
+sed -i '/<VirtualHost _default_:443>/,/<\/VirtualHost>/d' /etc/httpd/conf.d/ssl.conf
 _irods_environment_json
 _vhost_conf
 

--- a/4.2.2/docker-entrypoint.sh
+++ b/4.2.2/docker-entrypoint.sh
@@ -74,6 +74,7 @@ _vhost_conf () {
 }
 
 echo "IncludeOptional /etc/httpd/davrods_conf.d/*.conf" >> /etc/httpd/conf/httpd.conf
+sed -i '/<VirtualHost _default_:443>/,/<\/VirtualHost>/d' /etc/httpd/conf.d/ssl.conf
 _irods_environment_json
 _vhost_conf
 


### PR DESCRIPTION
The default ssl VirtualHost interferes with the ability to run
the davrods ssl VirtualHost.