### PR TITLE
Use httpd, not apachectl, in docker containers

### DIFF
--- a/4.2.1/docker-entrypoint.sh
+++ b/4.2.1/docker-entrypoint.sh
@@ -78,4 +78,4 @@ _irods_environment_json
 _vhost_conf
 
 # start the apache daemon
-exec /usr/sbin/apachectl -DFOREGROUND
+exec /usr/sbin/httpd -DFOREGROUND

--- a/4.2.2/docker-entrypoint.sh
+++ b/4.2.2/docker-entrypoint.sh
@@ -78,4 +78,4 @@ _irods_environment_json
 _vhost_conf
 
 # start the apache daemon
-exec /usr/sbin/apachectl -DFOREGROUND
+exec /usr/sbin/httpd -DFOREGROUND


### PR DESCRIPTION
apachectl doesn't pass signals properly, so httpd doesn't do
a graceful shutdown. This prevents the container from being
restarted, because the pid file remains.

Closes #9.